### PR TITLE
Corrige bug do score não ser zerado

### DIFF
--- a/play.js
+++ b/play.js
@@ -26,7 +26,7 @@ play.prototype = {
     var spaceKey = this.game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR);
     spaceKey.onDown.add(this.jump, this);
 
-    this.score = 0;
+    SCORE = 0;
     this.labelScore = this.game.add.text(20, 20, "0", { font: "30px Arial", fill: "#ffffff" });
 
     // Add the jump sound
@@ -91,9 +91,8 @@ play.prototype = {
           if (i != hole && i != hole +1)
             this.addOnePipe(400, i*60+10);
 
-          this.score += 1;
-          this.labelScore.text = this.score;
-          SCORE = this.score;
+          SCORE += 1;
+          this.labelScore.text = SCORE;
         },
 
 


### PR DESCRIPTION
Corrige bug que contagem de Pontos.
- Começar o jogo
- Fazer alguns pontos
- Deixar o capitão cair do cenário
- Quando começar outro jogo, deixa ele cair
- Deve mostrar a mensagem de pontos zerados e não mostrar a quantidade pontos conquistados anteriomente
